### PR TITLE
Rename MEDIUM_SIZED to Web Content.

### DIFF
--- a/config/install/core.entity_form_display.media.web_content.default.yml
+++ b/config/install/core.entity_form_display.media.web_content.default.yml
@@ -3,11 +3,11 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.media.medium_size.field_height
-    - field.field.media.medium_size.field_image
-    - field.field.media.medium_size.field_mimetype
+    - field.field.media.web_content.field_height
+    - field.field.media.web_content.field_image
+    - field.field.media.web_content.field_mimetype
     - image.style.thumbnail
-    - media_entity.bundle.medium_size
+    - media_entity.bundle.web_content
   enforced:
     module:
       - islandora_image
@@ -15,9 +15,9 @@ dependencies:
     - image
 _core:
   default_config_hash: BQYGAq_pqqoUpwvXC9X0VetW_I76vGEyJ5TRzJ7Jk60
-id: media.medium_size.default
+id: media.web_content.default
 targetEntityType: media
-bundle: medium_size
+bundle: web_content
 mode: default
 content:
   field_image:

--- a/config/install/core.entity_form_display.media.web_content.inline.yml
+++ b/config/install/core.entity_form_display.media.web_content.inline.yml
@@ -4,11 +4,11 @@ status: true
 dependencies:
   config:
     - core.entity_form_mode.media.inline
-    - field.field.media.medium_size.field_height
-    - field.field.media.medium_size.field_image
-    - field.field.media.medium_size.field_mimetype
+    - field.field.media.web_content.field_height
+    - field.field.media.web_content.field_image
+    - field.field.media.web_content.field_mimetype
     - image.style.thumbnail
-    - media_entity.bundle.medium_size
+    - media_entity.bundle.web_content
   enforced:
     module:
       - islandora_image
@@ -16,9 +16,9 @@ dependencies:
     - image
 _core:
   default_config_hash: ZXnucq5OfSp2B7Ae8WugvUQJCRuPpdDIGpO6iZV0vvA
-id: media.medium_size.inline
+id: media.web_content.inline
 targetEntityType: media
-bundle: medium_size
+bundle: web_content
 mode: inline
 content:
   field_image:

--- a/config/install/core.entity_form_display.node.islandora_image.default.yml
+++ b/config/install/core.entity_form_display.node.islandora_image.default.yml
@@ -6,7 +6,7 @@ dependencies:
     - core.entity_form_mode.media.inline
     - field.field.node.islandora_image.field_description
     - field.field.node.islandora_image.field_jp2
-    - field.field.node.islandora_image.field_medium_size
+    - field.field.node.islandora_image.field_web_content
     - field.field.node.islandora_image.field_memberof
     - field.field.node.islandora_image.field_obj
     - field.field.node.islandora_image.field_tn
@@ -49,7 +49,7 @@ content:
     third_party_settings: {  }
     type: inline_entity_form_complex
     region: content
-  field_medium_size:
+  field_web_content:
     weight: 10
     settings:
       form_mode: inline

--- a/config/install/core.entity_view_display.media.web_content.content.yml
+++ b/config/install/core.entity_view_display.media.web_content.content.yml
@@ -4,19 +4,19 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.content
-    - field.field.media.medium_size.field_height
-    - field.field.media.medium_size.field_image
-    - field.field.media.medium_size.field_mimetype
-    - field.field.media.medium_size.field_width
-    - media_entity.bundle.medium_size
+    - field.field.media.web_content.field_height
+    - field.field.media.web_content.field_image
+    - field.field.media.web_content.field_mimetype
+    - field.field.media.web_content.field_width
+    - media_entity.bundle.web_content
   enforced:
     module:
       - islandora_image
   module:
     - responsive_image
-id: media.medium_size.content
+id: media.web_content.content
 targetEntityType: media
-bundle: medium_size
+bundle: web_content
 mode: content
 content:
   field_image:

--- a/config/install/core.entity_view_display.media.web_content.default.yml
+++ b/config/install/core.entity_view_display.media.web_content.default.yml
@@ -3,20 +3,20 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.media.medium_size.field_height
-    - field.field.media.medium_size.field_image
-    - field.field.media.medium_size.field_mimetype
-    - field.field.media.medium_size.field_width
-    - media_entity.bundle.medium_size
+    - field.field.media.web_content.field_height
+    - field.field.media.web_content.field_image
+    - field.field.media.web_content.field_mimetype
+    - field.field.media.web_content.field_width
+    - media_entity.bundle.web_content
   enforced:
     module:
       - islandora_image
   module:
     - image
     - user
-id: media.medium_size.default
+id: media.web_content.default
 targetEntityType: media
-bundle: medium_size
+bundle: web_content
 mode: default
 content:
   created:

--- a/config/install/core.entity_view_display.node.islandora_image.default.yml
+++ b/config/install/core.entity_view_display.node.islandora_image.default.yml
@@ -5,7 +5,7 @@ dependencies:
   config:
     - field.field.node.islandora_image.field_description
     - field.field.node.islandora_image.field_jp2
-    - field.field.node.islandora_image.field_medium_size
+    - field.field.node.islandora_image.field_web_content
     - field.field.node.islandora_image.field_memberof
     - field.field.node.islandora_image.field_obj
     - field.field.node.islandora_image.field_tn
@@ -35,7 +35,7 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
-  field_medium_size:
+  field_web_content:
     weight: 106
     label: above
     settings:

--- a/config/install/core.entity_view_display.node.islandora_image.teaser.yml
+++ b/config/install/core.entity_view_display.node.islandora_image.teaser.yml
@@ -6,7 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.islandora_image.field_description
     - field.field.node.islandora_image.field_jp2
-    - field.field.node.islandora_image.field_medium_size
+    - field.field.node.islandora_image.field_web_content
     - field.field.node.islandora_image.field_memberof
     - field.field.node.islandora_image.field_obj
     - field.field.node.islandora_image.field_tn
@@ -44,6 +44,6 @@ content:
     third_party_settings: {  }
 hidden:
   field_jp2: true
-  field_medium_size: true
+  field_web_content: true
   field_memberof: true
   field_obj: true

--- a/config/install/field.field.media.web_content.field_height.yml
+++ b/config/install/field.field.media.web_content.field_height.yml
@@ -4,14 +4,14 @@ status: true
 dependencies:
   config:
     - field.storage.media.field_height
-    - media_entity.bundle.medium_size
+    - media_entity.bundle.web_content
   enforced:
     module:
       - islandora_image
-id: media.medium_size.field_height
+id: media.web_content.field_height
 field_name: field_height
 entity_type: media
-bundle: medium_size
+bundle: web_content
 label: Height
 description: 'Image Height'
 required: false

--- a/config/install/field.field.media.web_content.field_image.yml
+++ b/config/install/field.field.media.web_content.field_image.yml
@@ -4,25 +4,25 @@ status: true
 dependencies:
   config:
     - field.storage.media.field_image
-    - media_entity.bundle.medium_size
+    - media_entity.bundle.web_content
   enforced:
     module:
       - islandora_image
   module:
     - image
-id: media.medium_size.field_image
+id: media.web_content.field_image
 field_name: field_image
 entity_type: media
-bundle: medium_size
+bundle: web_content
 label: Image
-description: 'Image content for MEDIUM_SIZE'
+description: 'Image content for web_content'
 required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:
   file_directory: '[date:custom:Y]-[date:custom:m]'
-  file_extensions: 'jpg jpeg'
+  file_extensions: 'jpg jpeg gif png'
   max_filesize: ''
   max_resolution: ''
   min_resolution: ''

--- a/config/install/field.field.media.web_content.field_mimetype.yml
+++ b/config/install/field.field.media.web_content.field_mimetype.yml
@@ -4,14 +4,14 @@ status: true
 dependencies:
   config:
     - field.storage.media.field_mimetype
-    - media_entity.bundle.medium_size
+    - media_entity.bundle.web_content
   enforced:
     module:
       - islandora_image
-id: media.medium_size.field_mimetype
+id: media.web_content.field_mimetype
 field_name: field_mimetype
 entity_type: media
-bundle: medium_size
+bundle: web_content
 label: Mimetype
 description: ''
 required: false

--- a/config/install/field.field.media.web_content.field_width.yml
+++ b/config/install/field.field.media.web_content.field_width.yml
@@ -1,22 +1,25 @@
-uuid: 421077ad-9173-4c9b-a984-1ffa23b0116e
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.media.field_mimetype
-    - media_entity.bundle.medium_size
+    - media_entity.bundle.web_content
   enforced:
     module:
       - islandora_image
-id: media.medium_size.field_mimetype
-field_name: field_mimetype
+id: media.web_content.field_mimetype
+field_name: field_width
 entity_type: media
-bundle: medium_size
-label: Mimetype
-description: ''
+bundle: web_content
+label: Width
+description: 'Image Width'
 required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
-field_type: string
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/install/field.field.node.islandora_image.field_web_content.yml
+++ b/config/install/field.field.node.islandora_image.field_web_content.yml
@@ -3,17 +3,17 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_medium_size
-    - media_entity.bundle.medium_size
+    - field.storage.node.field_web_content
+    - media_entity.bundle.web_content
     - node.type.islandora_image
   enforced:
     module:
       - islandora_image
-id: node.islandora_image.field_medium_size
-field_name: field_medium_size
+id: node.islandora_image.field_web_content
+field_name: field_web_content
 entity_type: node
 bundle: islandora_image
-label: MEDIUM_SIZE
+label: Web Content
 description: 'Web copy of image for display'
 required: false
 translatable: false
@@ -23,7 +23,7 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
-      medium_size: medium_size
+      web_content: web_content
     sort:
       field: _none
     auto_create: false

--- a/config/install/field.field.node.islandora_image.field_web_content.yml
+++ b/config/install/field.field.node.islandora_image.field_web_content.yml
@@ -13,7 +13,7 @@ id: node.islandora_image.field_web_content
 field_name: field_web_content
 entity_type: node
 bundle: islandora_image
-label: Web Content
+label: Web Image
 description: 'Web copy of image for display'
 required: false
 translatable: false

--- a/config/install/field.storage.node.field_web_content.yml
+++ b/config/install/field.storage.node.field_web_content.yml
@@ -8,8 +8,8 @@ dependencies:
   enforced:
     module:
       - islandora_image
-id: node.field_medium_size
-field_name: field_medium_size
+id: node.field_web_content
+field_name: field_web_content
 entity_type: node
 type: entity_reference
 settings:

--- a/config/install/media_entity.bundle.web_content.yml
+++ b/config/install/media_entity.bundle.web_content.yml
@@ -9,8 +9,8 @@ dependencies:
     - media_entity_image
 _core:
   default_config_hash: q4LdttcDbI4bg5GX6Isqmf9ndMD00ko94AM5PA_7VhI
-id: medium_size
-label: MEDIUM_SIZE
+id: web_content
+label: Web Content
 description: 'Medium sized JPEG for web display'
 type: image
 queue_thumbnail_downloads: false

--- a/config/install/media_entity.bundle.web_content.yml
+++ b/config/install/media_entity.bundle.web_content.yml
@@ -10,7 +10,7 @@ dependencies:
 _core:
   default_config_hash: q4LdttcDbI4bg5GX6Isqmf9ndMD00ko94AM5PA_7VhI
 id: web_content
-label: Web Content
+label: Web Image
 description: 'Medium sized JPEG for web display'
 type: image
 queue_thumbnail_downloads: false

--- a/config/install/rdf.mapping.media.web_content.yml
+++ b/config/install/rdf.mapping.media.web_content.yml
@@ -2,15 +2,15 @@ langcode: en
 status: true
 dependencies:
   config:
-    - media_entity.bundle.medium_size
+    - media_entity.bundle.web_content
   enforced:
     module:
       - islandora_image
   module:
     - media_entity_image
-id: media.medium_size
+id: media.web_content
 targetEntityType: media
-bundle: medium_size
+bundle: web_content
 types:
   - 'use:ServiceFile'
 fieldMappings:

--- a/config/install/rdf.mapping.node.islandora_image.yml
+++ b/config/install/rdf.mapping.node.islandora_image.yml
@@ -33,7 +33,7 @@ fieldMappings:
     properties:
       - 'pcdm:hasFile'
     mapping_type: rel
-  field_medium_size:
+  field_web_content:
     properties:
       - 'pcdm:hasFile'
     mapping_type: rel


### PR DESCRIPTION
**GitHub Issue**: 
Resolves: https://github.com/Islandora-CLAW/CLAW/issues/675

# What does this Pull Request do?

Renames medium_size -> web_content in lots of files.

Also the width field was a copy of the mimetype field. Looks like it never got altered so there was actually no width field in the media bundle. I fixed this.

# What's new?

* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

1. Uninstall islandora_image
1. Pull this PR.
1. Install islandora_image

It should work exactly as before except that
1. The field is labelled "Web content"
1. The field allows "jpg, jpeg, gif and png" extensions.

# Interested parties
@Islandora-CLAW/committers 