### PR TITLE
Move image_obj to tiff_image

### DIFF
--- a/config/install/core.entity_form_display.media.image_tiff.default.yml
+++ b/config/install/core.entity_form_display.media.image_tiff.default.yml
@@ -3,8 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.media.image_obj.field_file
-    - media_entity.bundle.image_obj
+    - field.field.media.image_tiff.field_file
+    - media_entity.bundle.image_tiff
   enforced:
     module:
       - islandora_image
@@ -12,9 +12,9 @@ dependencies:
     - file
 _core:
   default_config_hash: NjNvUlZ7jFrfr5jP8goGnj5a5hYQZ-T-rKZUH4HMEBs
-id: media.image_obj.default
+id: media.image_tiff.default
 targetEntityType: media
-bundle: image_obj
+bundle: image_tiff
 mode: default
 content:
   field_file:

--- a/config/install/core.entity_form_display.media.image_tiff.inline.yml
+++ b/config/install/core.entity_form_display.media.image_tiff.inline.yml
@@ -4,8 +4,8 @@ status: true
 dependencies:
   config:
     - core.entity_form_mode.media.inline
-    - field.field.media.image_obj.field_file
-    - media_entity.bundle.image_obj
+    - field.field.media.image_tiff.field_file
+    - media_entity.bundle.image_tiff
   enforced:
     module:
       - islandora_image
@@ -13,9 +13,9 @@ dependencies:
     - file
 _core:
   default_config_hash: EtJ7MHMvbJSDO7jhctuoC4eWbci8r3WFI3zFVB3kDh8
-id: media.image_obj.inline
+id: media.image_tiff.inline
 targetEntityType: media
-bundle: image_obj
+bundle: image_tiff
 mode: inline
 content:
   field_file:

--- a/config/install/core.entity_form_display.node.islandora_image.default.yml
+++ b/config/install/core.entity_form_display.node.islandora_image.default.yml
@@ -8,7 +8,7 @@ dependencies:
     - field.field.node.islandora_image.field_jp2
     - field.field.node.islandora_image.field_medium_size
     - field.field.node.islandora_image.field_memberof
-    - field.field.node.islandora_image.field_obj
+    - field.field.node.islandora_image.field_tiff
     - field.field.node.islandora_image.field_tn
     - node.type.islandora_image
   module:
@@ -71,7 +71,7 @@ content:
     third_party_settings: {  }
     type: entity_reference_autocomplete
     region: content
-  field_obj:
+  field_tiff:
     weight: 8
     settings:
       form_mode: inline

--- a/config/install/core.entity_view_display.media.image_tiff.content.yml
+++ b/config/install/core.entity_view_display.media.image_tiff.content.yml
@@ -4,8 +4,8 @@ status: true
 dependencies:
   config:
     - core.entity_view_mode.media.content
-    - field.field.media.image_obj.field_file
-    - media_entity.bundle.image_obj
+    - field.field.media.image_tiff.field_file
+    - media_entity.bundle.image_tiff
   enforced:
     module:
       - islandora_image
@@ -14,9 +14,9 @@ dependencies:
     - user
 _core:
   default_config_hash: JvmSSfp_f0OmijViB2YSP7gOAQGkcOmESPNxRPcCl7s
-id: media.image_obj.content
+id: media.image_tiff.content
 targetEntityType: media
-bundle: image_obj
+bundle: image_tiff
 mode: content
 content:
   created:

--- a/config/install/core.entity_view_display.media.image_tiff.default.yml
+++ b/config/install/core.entity_view_display.media.image_tiff.default.yml
@@ -3,8 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.field.media.image_obj.field_file
-    - media_entity.bundle.image_obj
+    - field.field.media.image_tiff.field_file
+    - media_entity.bundle.image_tiff
   enforced:
     module:
       - islandora_image
@@ -12,9 +12,9 @@ dependencies:
     - file
 _core:
   default_config_hash: JvmSSfp_f0OmijViB2YSP7gOAQGkcOmESPNxRPcCl7s
-id: media.image_obj.default
+id: media.image_tiff.default
 targetEntityType: media
-bundle: image_obj
+bundle: image_tiff
 mode: default
 content:
   field_file:

--- a/config/install/core.entity_view_display.node.islandora_image.default.yml
+++ b/config/install/core.entity_view_display.node.islandora_image.default.yml
@@ -7,7 +7,7 @@ dependencies:
     - field.field.node.islandora_image.field_jp2
     - field.field.node.islandora_image.field_medium_size
     - field.field.node.islandora_image.field_memberof
-    - field.field.node.islandora_image.field_obj
+    - field.field.node.islandora_image.field_tiff
     - field.field.node.islandora_image.field_tn
     - node.type.islandora_image
   module:
@@ -52,7 +52,7 @@ content:
     third_party_settings: {  }
     type: entity_reference_label
     region: content
-  field_obj:
+  field_tiff:
     weight: 103
     label: above
     settings:

--- a/config/install/core.entity_view_display.node.islandora_image.teaser.yml
+++ b/config/install/core.entity_view_display.node.islandora_image.teaser.yml
@@ -8,7 +8,7 @@ dependencies:
     - field.field.node.islandora_image.field_jp2
     - field.field.node.islandora_image.field_medium_size
     - field.field.node.islandora_image.field_memberof
-    - field.field.node.islandora_image.field_obj
+    - field.field.node.islandora_image.field_tiff
     - field.field.node.islandora_image.field_tn
     - node.type.islandora_image
   module:
@@ -46,4 +46,4 @@ hidden:
   field_jp2: true
   field_medium_size: true
   field_memberof: true
-  field_obj: true
+  field_tiff: true

--- a/config/install/field.field.media.image_tiff.field_file.yml
+++ b/config/install/field.field.media.image_tiff.field_file.yml
@@ -4,16 +4,16 @@ status: true
 dependencies:
   config:
     - field.storage.media.field_file
-    - media_entity.bundle.image_obj
+    - media_entity.bundle.image_tiff
   enforced:
     module:
       - islandora_image
   module:
     - file
-id: media.image_obj.field_file
+id: media.image_tiff.field_file
 field_name: field_file
 entity_type: media
-bundle: image_obj
+bundle: image_tiff
 label: File
 description: 'Preservation master contents for an Islandora Image object.'
 required: false

--- a/config/install/field.field.node.islandora_image.field_tiff.yml
+++ b/config/install/field.field.node.islandora_image.field_tiff.yml
@@ -3,17 +3,17 @@ langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.node.field_obj
-    - media_entity.bundle.image_obj
+    - field.storage.node.field_tiff
+    - media_entity.bundle.image_tiff
     - node.type.islandora_image
   enforced:
     module:
       - islandora_image
-id: node.islandora_image.field_obj
-field_name: field_obj
+id: node.islandora_image.field_tiff
+field_name: field_tiff
 entity_type: node
 bundle: islandora_image
-label: OBJ
+label: 'Tiff image'
 description: 'Preservation master'
 required: false
 translatable: true
@@ -23,7 +23,7 @@ settings:
   handler: 'default:media'
   handler_settings:
     target_bundles:
-      image_obj: image_obj
+      image_tiff: image_tiff
     sort:
       field: _none
     auto_create: false

--- a/config/install/field.storage.node.field_tiff.yml
+++ b/config/install/field.storage.node.field_tiff.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media_entity
+    - node
+  enforced:
+    module:
+      - islandora_image
+id: node.field_tiff
+field_name: field_tiff
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/media_entity.bundle.image_tiff.yml
+++ b/config/install/media_entity.bundle.image_tiff.yml
@@ -9,8 +9,8 @@ dependencies:
     - media_entity_image
 _core:
   default_config_hash: fi5draAS7BCkytyHpaeYa-daLPsuKPstOA0qVohDVcI
-id: image_obj
-label: 'Image OBJ'
+id: image_tiff
+label: 'Tiff image'
 description: 'Preservation master file for an Islandora Image'
 type: image
 queue_thumbnail_downloads: false

--- a/config/install/rdf.mapping.media.image_tiff.yml
+++ b/config/install/rdf.mapping.media.image_tiff.yml
@@ -2,15 +2,15 @@ langcode: en
 status: true
 dependencies:
   config:
-    - media_entity.bundle.image_obj
+    - media_entity.bundle.image_tiff
   enforced:
     module:
       - islandora_image
   module:
     - media_entity
-id: media.image_obj
+id: media.image_tiff
 targetEntityType: media
-bundle: image_obj
+bundle: image_tiff
 types:
   - 'use:PreservationMasterFile'
 fieldMappings:

--- a/config/install/rdf.mapping.node.islandora_image.yml
+++ b/config/install/rdf.mapping.node.islandora_image.yml
@@ -25,7 +25,7 @@ fieldMappings:
     properties:
       - 'pcdm:memberOf'
     mapping_type: rel
-  field_obj:
+  field_tiff:
     properties:
       - 'pcdm:hasFile'
     mapping_type: rel


### PR DESCRIPTION
**GitHub Issue**: 
Resolves: https://github.com/Islandora-CLAW/CLAW/issues/677

# What does this Pull Request do?

Renames image_obj to image_tiff, also adds field_tiff storage config.
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# How should this be tested?

1. Uninstall islandora_image
1. Pull in this PR.
1. Install islandora_image
1. See that OBJ is now "Tiff image", but otherwise no difference.

# Interested parties
@Islandora-CLAW/committers