### PR TITLE
Re-exporting tiff and jp2 bundle yml

### DIFF
--- a/config/install/media_entity.bundle.image_tiff.yml
+++ b/config/install/media_entity.bundle.image_tiff.yml
@@ -8,7 +8,7 @@ dependencies:
   module:
     - media_entity_image
 _core:
-  default_config_hash: fi5draAS7BCkytyHpaeYa-daLPsuKPstOA0qVohDVcI
+  default_config_hash: xYLwsfDi0VZuixIK_k-w8y7hoRSS3S3gkZplXHHcWYY
 id: image_tiff
 label: 'Tiff image'
 description: 'Preservation master file for an Islandora Image'
@@ -16,6 +16,6 @@ type: image
 queue_thumbnail_downloads: false
 new_revision: false
 type_configuration:
-  source_field: field_image
+  source_field: field_file
   gather_exif: false
 field_map: {  }

--- a/config/install/media_entity.bundle.jp2.yml
+++ b/config/install/media_entity.bundle.jp2.yml
@@ -5,13 +5,17 @@ dependencies:
   enforced:
     module:
       - islandora_image
+  module:
+    - media_entity_image
 _core:
-  default_config_hash: EGGUWkUHg58NLhG5q1lIo8TsZhrU4PMYW9KoGAqPAzY
+  default_config_hash: iypCon-6qIVQAQncmw_EpG9FpBUL5WJVuwrQ5Nq0z2U
 id: jp2
 label: JP2
 description: 'JPEG2000 service file'
-type: generic
+type: image
 queue_thumbnail_downloads: false
 new_revision: false
-type_configuration: {  }
+type_configuration:
+  source_field: field_file
+  gather_exif: false
 field_map: {  }


### PR DESCRIPTION
**GitHub Issue**: Resolves https://github.com/Islandora-CLAW/CLAW/issues/816

# What does this Pull Request do?

Re-exports our yml for tiff and jp2 media bundles.

# What's new?
Just the new yml.  The important bits are that the source fields are set to `field_file`

# How should this be tested?

Delete the bundles and re-import them using the files in this PR.  You can use drupal/drush or Drupal's config synchronization UI.

After that, you should be able to add tiffs and jp2s to `islandora_image` objects using the REST API.

For JP2:
```bash
curl -X POST -u admin:islandora -H "Content-Type: image/jp2" -H "Content-Disposition: attachment; filename=\"sample.jp2\"" --data-binary @sample.jp2 http://localhost:8000/node/2/media/field_jp2/add/jp2
```

For TIFF:
```
curl -X POST -u admin:islandora -H "Content-Type: image/tiff" -H "Content-Disposition: attachment; filename=\"test.tiff\"" --data-binary @test.tiff http://localhost:8000/node/2/media/field_tiff/add/image_tiff
```

# Interested parties
@mjordan @Islandora-CLAW/committers