### PR TITLE
Throwing exceptions if media/terms don't exist when populating event …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@
 sudo: true
 language: php
 php:
-  - 5.6
-  - 7.0
   - 7.1
+  - 7.2
 
 matrix:
     fast_finish: true
@@ -31,7 +30,7 @@ script:
   - $SCRIPT_DIR/line_endings.sh $TRAVIS_BUILD_DIR
   - phpcs --standard=Drupal --ignore=*.md --extensions=php,module,inc,install,test,profile,theme,css,info $TRAVIS_BUILD_DIR
   - phpcpd --names *.module,*.inc,*.test,*.php $TRAVIS_BUILD_DIR
-  - php core/scripts/run-tests.sh --url http://127.0.0.1:8282 --verbose --php `which php` --module "islandora_image"
+  - php core/scripts/run-tests.sh --url http://127.0.0.1:8282 --suppress-deprecations --verbose --php `which php` --module "islandora_image"
 
 notifications:
   irc:

--- a/src/Plugin/Action/GenerateImageDerivative.php
+++ b/src/Plugin/Action/GenerateImageDerivative.php
@@ -130,15 +130,35 @@ class GenerateImageDerivative extends EmitEvent {
     // Find media belonging to node that has the source term, and set its file
     // url in the data array.
     $source_term = $this->utils->getTermForUri($this->configuration['source_term_uri']);
+    if (!$source_term) {
+      throw new \RuntimeException("Could not locate source term with uri" . $this->configuration['source_term_uri'], 500);
+    }
+
     $source_media = $this->utils->getMediaWithTerm($entity, $source_term);
+    if (!$source_media) {
+      throw new \RuntimeException("Could not locate source media", 500);
+    }
+
     $source_field = $this->mediaSource->getSourceFieldName($source_media->bundle());
+    if (!$source_field) {
+      throw new \RuntimeException("Could not locate source field for media {$source_media->id()}", 500);
+    }
+
     $files = $source_media->get($source_field)->referencedEntities();
     $file = reset($files);
+    if (!$file) {
+      throw new \RuntimeException("Could not locate source file for media {$source_media->id()}", 500);
+    }
+
     $data['source_uri'] = $file->url('canonical', ['absolute' => TRUE]);
 
     // Find the term for the derivative and use it to set the destination url
     // in the data array.
     $derivative_term = $this->utils->getTermForUri($this->configuration['derivative_term_uri']);
+    if (!$source_term) {
+      throw new \RuntimeException("Could not locate derivative term with uri" . $this->configuration['derivative_term_uri'], 500);
+    }
+
     $route_params = [
       'node' => $entity->id(),
       'media_type' => 'image',


### PR DESCRIPTION
…data

**GitHub Issue**: Islandora-CLAW/CLAW#846

- https://github.com/Islandora-CLAW/islandora/pull/93

# What does this Pull Request do?

Throws exceptions when things go awry instead of WSODing.

# What's new?
Sniffing return results and throwing excpetions for any number of things that can return null, so that they can be caught elsewhere and handled properly instead of WSODing.

# How should this be tested?

Pull down this code.  Pull down https://github.com/Islandora-CLAW/islandora/pull/93.  Clear your cache. Try to generate an image derivative from a source that does not exist (e.g. you have no preservation master, and request a source file).  You should get a dsm and a log entry that have the exception message in it.  No WSOD.

# Interested parties
Here's an easy one to test @manez, @Islandora-CLAW/committers